### PR TITLE
Fix Heroku: "  Line 18:8:  React Hook useEffect has a missing depende…

### DIFF
--- a/web-frontend/src/pages/BoxDetailsPage.tsx
+++ b/web-frontend/src/pages/BoxDetailsPage.tsx
@@ -15,7 +15,7 @@ export default function BoxDetailsPage({boxItems, getBoxItems}: BoxDetailsPagePr
         if (id) {
             getBoxItems(id)
         }
-    }, [id])
+    }, [id, getBoxItems])
 
     return (
         <div className={"box-items"}>


### PR DESCRIPTION
…ncy: 'getBoxItems'. Either include it or remove the dependency array. If 'getBoxItems' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps"

Will merge with Admin privileges.