### PR TITLE
#37 delete box

### DIFF
--- a/web-frontend/src/App.tsx
+++ b/web-frontend/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
     const {subscriptions, userDetails,
         subscribeToBox, boxItems,
         getBoxItems, subscribables,
-        removeFromSubscription} = useUserDetailsBoxesAndBoxItems()
+        removeFromSubscriptionOnce} = useUserDetailsBoxesAndBoxItems()
 
     return (
         <div className="App">
@@ -31,7 +31,7 @@ function App() {
                            element={<OverviewPage
                                subscribeToBox={subscribeToBox}
                                subscriptions={subscriptions}
-                               removeFromSubscription={removeFromSubscription}
+                               removeFromSubscriptionOnce={removeFromSubscriptionOnce}
                                userDetails={userDetails}
                                subscribables={subscribables}
                            />}

--- a/web-frontend/src/components/Abonnements.tsx
+++ b/web-frontend/src/components/Abonnements.tsx
@@ -10,20 +10,18 @@ type AbonnementProps = {
     userDetails: UserDetails | undefined
     subscribeToBox: (boxId: string) => void
     subscribables: SubscriptionOverviewDto[] | undefined
-    removeFromSubscription: (boxId: string) => void | undefined
+    removeFromSubscriptionOnce: (boxId: string) => void | undefined
 }
 
 export default function Abonnements(
-    {subscriptions, userDetails, subscribeToBox, removeFromSubscription, subscribables}: AbonnementProps
+    {subscriptions, subscribeToBox, removeFromSubscriptionOnce, subscribables}: AbonnementProps
 ) {
 
     const navigate = useNavigate()
 
     return <div>
         <h2>Biokisten</h2><NewSubscription
-        userDetails={userDetails}
         subscribeToBox={subscribeToBox}
-        removeFromSubscription={removeFromSubscription}
         subscribables={subscribables}
         />
         <h2>Abonnements</h2>
@@ -31,7 +29,7 @@ export default function Abonnements(
         subscriptions.map(sub =>
             <div><div className="AboElement" id="active" onClick={() => navigate('/box/' + sub.id)}>
                 {sub.name}
-            </div><div id="active" onClick={() => removeFromSubscription(sub.id)}><AiOutlineMinus/></div></div>
+            </div><div id="active" onClick={() => removeFromSubscriptionOnce(sub.id)}><AiOutlineMinus/></div></div>
         )}
     </div>
 }

--- a/web-frontend/src/components/Abonnements.tsx
+++ b/web-frontend/src/components/Abonnements.tsx
@@ -1,13 +1,11 @@
 import {Subscription} from "../model/Subscription";
 import {useNavigate} from "react-router-dom";
-import {UserDetails} from "../model/UserDetails";
 import NewSubscription from "./NewSubscription";
 import {SubscriptionOverviewDto} from "../dto/SubscriptionOverviewDto";
 import {AiOutlineMinus} from "react-icons/ai";
 
 type AbonnementProps = {
     subscriptions: Subscription[] | undefined
-    userDetails: UserDetails | undefined
     subscribeToBox: (boxId: string) => void
     subscribables: SubscriptionOverviewDto[] | undefined
     removeFromSubscriptionOnce: (boxId: string) => void | undefined

--- a/web-frontend/src/components/NewSubscription.tsx
+++ b/web-frontend/src/components/NewSubscription.tsx
@@ -1,12 +1,9 @@
-import {UserDetails} from "../model/UserDetails";
 import {SubscriptionOverviewDto} from "../dto/SubscriptionOverviewDto";
 import {AiOutlinePlus} from "react-icons/ai";
 
 type NewSubscriptionProps = {
-    userDetails: UserDetails | undefined
     subscribeToBox: (boxId: string) => void
     subscribables: SubscriptionOverviewDto[] | undefined
-    removeFromSubscription: (boxId: string) => void | undefined
 }
 
 export default function NewSubscription({ subscribeToBox, subscribables}: NewSubscriptionProps ) {

--- a/web-frontend/src/context/AuthProvider.tsx
+++ b/web-frontend/src/context/AuthProvider.tsx
@@ -6,9 +6,7 @@ import axios from "axios";
 const AUTH_KEY = "AuthToken"
 
 
-export const AuthContext = createContext<{
-    token: string | undefined,
-    login: (credentials: {username: string, password: string}) => void }> (
+export const AuthContext = createContext<{ token: string | undefined, login: (credentials: {username: string, password: string}) => void }> (
         {token: undefined, login: () => {toast.error("Login not initialized.")}}
 )
 

--- a/web-frontend/src/hooks/useUserDetailsBoxesAndBoxItems.ts
+++ b/web-frontend/src/hooks/useUserDetailsBoxesAndBoxItems.ts
@@ -24,15 +24,19 @@ export default function useUserDetailsBoxesAndBoxItems(){
         getUserDetails(token)
             .then(details => setUserDetails(details))
             .catch(() => toast.error("Connection failed to get user details. Please retry."))
-        getSubscriptions(token)
-            .then(subs => setSubscriptions(subs))
-            .catch(() => toast.error("Connection failed to get abonnements. Please retry."))
+        token && readSubscriptions(token)
         getAllPossibleSubscriptions()
             .then(data => {
                 setSubscribables(data)
             })
             .catch(error => toast.error(error))
     }, [token])
+
+    const readSubscriptions = (token: string) => {
+        getSubscriptions(token)
+            .then(subs => setSubscriptions(subs))
+            .catch(() => toast.error("Connection failed to get abonnements. Please retry."))
+    }
 
     const getBoxItems = (id: string) => {
         getBoxItemsByBoxId(id, token)
@@ -49,11 +53,26 @@ export default function useUserDetailsBoxesAndBoxItems(){
     const removeFromSubscription = (boxId: string) => {
         removeUserSubscriptionFromBox(boxId, token)
             .then(() => {
-                    subscriptions ?? toast.info("Removing subscription")
-                    setSubscriptions(subscriptions.filter(subscriptions => subscriptions.id !== boxId))
-                }
-            )
+                    toast.info("Removing subscription " + boxId)
+                })
+            .then(() => {setSubscriptions(removeSubscriptionOnce(boxId))})
             .catch(error => toast.error(error))
+    }
+
+    const removeSubscriptionOnce = (boxId: string) => {
+        toast.info("Removing " + boxId)
+
+        function removeCustomerOnceFromSubscrion(subscription: Subscription) {
+            return userDetails &&
+                userDetails.id &&
+                subscription.customers.splice(subscription.customers.findIndex(() => userDetails.id));
+        }
+
+        subscriptions.map(subscription => {
+            removeCustomerOnceFromSubscrion(subscription)
+        })
+        token && readSubscriptions(token)
+        return subscriptions
     }
 
     return {userDetails, subscriptions, boxItems, removeFromSubscription, getBoxItems, subscribeToBox, subscribables}

--- a/web-frontend/src/hooks/useUserDetailsBoxesAndBoxItems.ts
+++ b/web-frontend/src/hooks/useUserDetailsBoxesAndBoxItems.ts
@@ -62,14 +62,14 @@ export default function useUserDetailsBoxesAndBoxItems(){
     const removeSubscriptionOnce = (boxId: string) => {
         toast.info("Removing " + boxId)
 
-        function removeCustomerOnceFromSubscrion(subscription: Subscription) {
+        function removeCustomerOnceFromSubscription(subscription: Subscription) {
             return userDetails &&
                 userDetails.id &&
                 subscription.customers.splice(subscription.customers.findIndex(() => userDetails.id));
         }
 
         subscriptions.map(subscription => {
-            removeCustomerOnceFromSubscrion(subscription)
+            return removeCustomerOnceFromSubscription(subscription)
         })
         token && readSubscriptions(token)
         return subscriptions

--- a/web-frontend/src/hooks/useUserDetailsBoxesAndBoxItems.ts
+++ b/web-frontend/src/hooks/useUserDetailsBoxesAndBoxItems.ts
@@ -24,7 +24,6 @@ export default function useUserDetailsBoxesAndBoxItems(){
         getUserDetails(token)
             .then(details => setUserDetails(details))
             .catch(() => toast.error("Connection failed to get user details. Please retry."))
-        token && readSubscriptions(token)
         getAllPossibleSubscriptions()
             .then(data => {
                 setSubscribables(data)
@@ -32,7 +31,12 @@ export default function useUserDetailsBoxesAndBoxItems(){
             .catch(error => toast.error(error))
     }, [token])
 
-    const readSubscriptions = (token: string) => {
+    useEffect(() => {
+        readSubscriptions()
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [subscriptions])
+
+    const readSubscriptions = () => {
         getSubscriptions(token)
             .then(subs => setSubscriptions(subs))
             .catch(() => toast.error("Connection failed to get abonnements. Please retry."))
@@ -50,28 +54,11 @@ export default function useUserDetailsBoxesAndBoxItems(){
             .catch(error => toast.error(error))
     }
 
-    const removeFromSubscription = (boxId: string) => {
-        removeUserSubscriptionFromBox(boxId, token)
-        setSubscriptions(subscriptions.filter(
-            subscription => subscription.id !== boxId)
-        )
-    }
-
-    const removeSubscriptionOnce = (boxId: string) => {
+    const removeFromSubscriptionOnce = (boxId: string) => {
         toast.info("Removing " + boxId)
-
-        function removeCustomerOnceFromSubscription(subscription: Subscription) {
-            return userDetails &&
-                userDetails.id &&
-                subscription.customers.splice(subscription.customers.findIndex(() => userDetails.id));
-        }
-
-        subscriptions.map(subscription => {
-            return removeCustomerOnceFromSubscription(subscription)
-        })
-        token && readSubscriptions(token)
-        return subscriptions
+        removeUserSubscriptionFromBox(boxId, token)
+        readSubscriptions()
     }
 
-    return {userDetails, subscriptions, boxItems, removeFromSubscription, getBoxItems, subscribeToBox, subscribables}
+    return {userDetails, subscriptions, boxItems, removeFromSubscriptionOnce, getBoxItems, subscribeToBox, subscribables}
 }

--- a/web-frontend/src/pages/OverviewPage.tsx
+++ b/web-frontend/src/pages/OverviewPage.tsx
@@ -9,11 +9,11 @@ type OverviewPageProps= {
     subscriptions: Subscription[] | undefined
     userDetails: UserDetails | undefined
     subscribables: SubscriptionOverviewDto[] | undefined
-    removeFromSubscription: (boxId: string) => void | undefined
+    removeFromSubscriptionOnce: (boxId: string) => void | undefined
 }
 
 export default function OverviewPage(
-    {subscribeToBox, removeFromSubscription, subscriptions, userDetails, subscribables}: OverviewPageProps
+    {subscribeToBox, removeFromSubscriptionOnce, subscriptions, userDetails, subscribables}: OverviewPageProps
 ) {
 
     return (
@@ -23,7 +23,7 @@ export default function OverviewPage(
                 subscriptions={subscriptions}
                 userDetails={userDetails}
                 subscribeToBox={subscribeToBox}
-                removeFromSubscription={removeFromSubscription}
+                removeFromSubscriptionOnce={removeFromSubscriptionOnce}
                 subscribables={subscribables}/>
         </div>
     )


### PR DESCRIPTION
The user can now unsubscribe from a box.

I made some mistakes in the last PR, where - after Code Review or without reviewing it - delete tests, endpoints, and first functionality was already deployed. So, please check the branch "#37-delete-inbox" out, have a look at the changes listed here (on Github), and please have at least a look on the delete tests in controller (DeleteTest.java). If you are curious, you can follow the path the function "removeFromSubscriptionOnce" goes from App.tsx to "Abonnements".