### PR TITLE
Buttons are now besides items, toggling is fixed

### DIFF
--- a/web-frontend/src/components/Abonnements.tsx
+++ b/web-frontend/src/components/Abonnements.tsx
@@ -3,6 +3,7 @@ import {useNavigate} from "react-router-dom";
 import NewSubscription from "./NewSubscription";
 import {SubscriptionOverviewDto} from "../dto/SubscriptionOverviewDto";
 import {AiOutlineMinus} from "react-icons/ai";
+import "./ItemOrBoxes.css"
 
 type AbonnementProps = {
     subscriptions: Subscription[] | undefined
@@ -23,10 +24,12 @@ export default function Abonnements(
         subscribables={subscribables}
     />
         <h2>Abonnements</h2>
+        <div>
         {subscriptions &&
             subscriptions.map((sub, idx) =>
-                <div key={idx}>
-                    <button className="AboElement"
+                <div className="item-or-box" key={idx}>
+                    <div id="inactive"></div>
+                    <button className="growable"
                             id="active"
                             onClick={() => navigate('/box/' + sub.id)}
                     >
@@ -39,5 +42,6 @@ export default function Abonnements(
                     </button>
                 </div>
             )}
+        </div>
     </div>
 }

--- a/web-frontend/src/components/BoxItem.tsx
+++ b/web-frontend/src/components/BoxItem.tsx
@@ -9,8 +9,8 @@ type ItemProps = {
 
 export default function BoxItem({item, removeItemFromBox, boxId}: ItemProps) {
     return (
-        <div>
-            <div id="inactive">
+        <div className="item-or-box">
+            <div className="growable" id="inactive">
                 {item.name}
             </div>
             <button id="active" onClick={() => {

--- a/web-frontend/src/components/ItemOrBoxes.css
+++ b/web-frontend/src/components/ItemOrBoxes.css
@@ -1,0 +1,8 @@
+.item-or-box {
+    display: flex;
+    justify-content: space-between;
+}
+
+.growable {
+    flex-grow: 2;
+}

--- a/web-frontend/src/components/NewSubscription.tsx
+++ b/web-frontend/src/components/NewSubscription.tsx
@@ -1,5 +1,7 @@
 import {SubscriptionOverviewDto} from "../dto/SubscriptionOverviewDto";
 import {AiOutlinePlus} from "react-icons/ai";
+import "./ItemOrBoxes.css"
+import {useNavigate} from "react-router-dom";
 
 type NewSubscriptionProps = {
     subscribeToBox: (boxId: string) => void
@@ -8,16 +10,22 @@ type NewSubscriptionProps = {
 
 export default function NewSubscription({ subscribeToBox, subscribables}: NewSubscriptionProps ) {
 
+    const navigate = useNavigate()
+
     return <div>
         {subscribables &&
             subscribables.map(
                 subsls =>
-                    <div key={subsls.id}>
+                    <div className="item-or-box" key={subsls.id}>
+                        <div id="inactive"></div>
+                        <button className="AboElement growable"
+                                id="active"
+                                onClick={() => navigate('/box/' + subsls.id)}
+                        >{subsls.name}</button>
                         <button id="active" onClick={
                             () => subscribeToBox(subsls.id)
                         }><AiOutlinePlus/>
                         </button>
-                        <div>{subsls.name}</div>
                     </div>)}
     </div>
 }

--- a/web-frontend/src/components/ProviderItem.tsx
+++ b/web-frontend/src/components/ProviderItem.tsx
@@ -2,6 +2,7 @@ import {Item} from "../model/Item";
 import {AiOutlineEdit, AiOutlinePlus, AiOutlineSend} from "react-icons/ai";
 import {ItemDto} from "../dto/ItemDto";
 import {FormEvent, useState} from "react";
+import "./ItemOrBoxes.css"
 
 type ItemProps = {
     item: Item
@@ -21,12 +22,14 @@ export default function ProviderItem({item, addItemToBox, boxId, changeItemName}
     }
 
     return (
-        <div>
+        <div className="item-or-box">
+            <button id="active" onClick={() => {
+                boxId && addItemToBox(boxId, item.id)
+            }}>
+                <AiOutlinePlus/>
+            </button>
             {isNameEditable ?
-                <div id="inactive">
-                    {item.name}
-                </div> :
-                <form onSubmit={onSubmit}>
+                <form className="growable" onSubmit={onSubmit}>
                     <input type={"text"}
                            value={newName}
                            placeholder={item.name}
@@ -35,13 +38,11 @@ export default function ProviderItem({item, addItemToBox, boxId, changeItemName}
                     <button type={"submit"} id="active">
                         <AiOutlineSend/>
                     </button>
-                </form>
+                </form> :
+                <div className="growable" id="inactive">
+                    {item.name}
+                </div>
             }
-            <button id="active" onClick={() => {
-                boxId && addItemToBox(boxId, item.id)
-            }}>
-                <AiOutlinePlus/>
-            </button>
             <button id="active" onClick={() => {
                 setIsNameEditable(!isNameEditable)
             }}>

--- a/web-frontend/src/pages/BoxDetailsPage.tsx
+++ b/web-frontend/src/pages/BoxDetailsPage.tsx
@@ -54,7 +54,7 @@ export default function BoxDetailsPage({
     return (
         <div className={"box-items"}>
             <h1>
-                {element && element.name}
+                {element ? element.name : "Content of Box"}
             </h1>
             {boxItems && boxItems.map((item, idx) =>
                 <BoxItem key={item.id + "-" + idx}


### PR DESCRIPTION
- Fixed toggle: BoxDetailsPage starts without editing note.
- Buttons for add, delete, and edit are now besides item names.
- Items are fill now the place between buttons.

Todo: Somehow the box name does not appear in BoxDetailsPage.tsx (this does not give a return: {element ? element.name : "Content of Box"}).